### PR TITLE
Fix layout overflow issues and adjust z-index

### DIFF
--- a/app/(home)/layout.tsx
+++ b/app/(home)/layout.tsx
@@ -4,7 +4,7 @@ import Sidebar from "../components/Sidebar";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <main className="flex w-full h-full">
+    <main className="flex w-full h-[100svh]">
       <Sidebar />
       {children}
     </main>

--- a/app/(home)/notes/[details]/page.tsx
+++ b/app/(home)/notes/[details]/page.tsx
@@ -106,7 +106,7 @@ const NoteDetails = ({ params }: { params: any }) => {
   return (
     <ProtectedRoute>
       <div className="p-5 w-full h-full">
-        <div className="h-full">
+        <div className="h-full overflow-auto">
           <div className="flex items-center justify-center flex-col">
             <div className="flex items-center justify-start w-full dark:text-white text-text">
               <button
@@ -146,7 +146,7 @@ const NoteDetails = ({ params }: { params: any }) => {
               formats={formats}
               theme="snow"
               style={{ height: "500px" }}
-              className="dark:text-white text-[#131313] mb-16"
+              className="dark:text-white text-[#131313] mb-16 -z-10"
             />
           </div>
         </div>


### PR DESCRIPTION
**Description:**
This pull request addresses layout overflow issues and improves the overall user experience:

- Adjusted the layout height to `100svh` to prevent notes from overflowing.
- Applied `overflow-auto` to the Note Details section to prevent content overflow.
- Changed the z-index of the editor to `-z-10` to ensure it appears below the sidebar.

**Screenshots:**

User
make this screenshot be in a grid layout in a row and of the same size

**Before:**
<div style="display: flex; flex-wrap: wrap; gap: 10px;">
    <img src="https://i.ibb.co/BZKLw1X/Firefox-Screenshot-2024-02-14-T17-21-51-374-Z.png" alt="Before1" width="300" />
    <img src="https://i.ibb.co/TWx7XCw/Firefox-Screenshot-2024-02-14-T17-17-32-065-Z.png" alt="Before2" width="300" />
    <img src="https://i.ibb.co/85Xs2tM/Firefox-Screenshot-2024-02-14-T17-18-23-603-Z.png" alt="Before3" width="300" />
</div>

---

**After:**
<div style="display: flex; flex-wrap: wrap; gap: 10px;">
    <img src="https://i.ibb.co/s5kPFg1/Firefox-Screenshot-2024-02-14-T17-38-21-478-Z.png" alt="After1" width="300" />
    <img src="https://i.ibb.co/ZJnQvCZ/Firefox-Screenshot-2024-02-14-T17-25-21-304-Z.png" alt="After2" width="300" />
</div>
